### PR TITLE
SPARQL-related modifications to Turtle formatting

### DIFF
--- a/lib/Tuba/files/templates/book/object.ttl.tut
+++ b/lib/Tuba/files/templates/book/object.ttl.tut
@@ -2,9 +2,8 @@
 %= filter_lines_with empty_predicate() => begin
 
 <<%= current_resource %>>
-## Identifier, title, and publication year
    dcterms:identifier "<%= $book->identifier %>";
-   dcterms:title "<%= $book->title %>"^^xsd:string;
+   dcterms:title """<%= $book->title %>"""^^xsd:string;
    dwc:year "<%= $book->year %>"^^xsd:gYear;
    bibo:isbn "<%= $book->isbn %>";
    bibo:numPages "<%= $book->number_of_pages %>"^^xsd:integer;

--- a/lib/Tuba/files/templates/dataset/object.ttl.tut
+++ b/lib/Tuba/files/templates/dataset/object.ttl.tut
@@ -9,14 +9,14 @@
    datacite:doi "<%= $dataset->doi %>";
    datacite:AlternateResourceIdentifier "<%= $dataset->native_id %>";
    gcis:accessURL "<%= $dataset->url %>"^^xsd:anyURI;
-   cito:citesAsMetadataDocument "<%= $dataset->cite_metadata %>";
+   cito:citesAsMetadataDocument """<%= $dataset->cite_metadata %>""";
 
 ## The formal description of the dataset
-   dcterms:description "<%= no_tbibs($dataset->description) %>"^^xsd:string;
+   dcterms:description """<%= no_tbibs($dataset->description) %>"""^^xsd:string;
  
 ## Dates of dataset release and access
-   dcterms:issued "<%= $dataset->release_dt %>"^^xsd:date;
-   dcterms:date "<%= $dataset->access_dt %>"^^xsd:date;
+   dcterms:issued "<%= $dataset->release_dt %>"^^xsd:dateTime;
+   dcterms:date "<%= $dataset->access_dt %>"^^xsd:dateTime;
 
 ## Projection and resolution:
    gcis:spatialExtents "<%= $dataset->spatial_extent %>";

--- a/lib/Tuba/files/templates/dataset/prov.ttl.tut
+++ b/lib/Tuba/files/templates/dataset/prov.ttl.tut
@@ -12,8 +12,8 @@
     %       push @{ $by_type_rel{$type}{$rel}}, $child->publication;
 
 <<%= obj_uri_for($child->{publication}->to_object)->to_abs %>>
-    % for my $r ($child->publication->to_object) {
-   a gcis:<%= ucfirst($r->meta->table) %>;
+    % for my $foo ($child->publication->to_object) {
+   a gcis:<%= ucfirst($foo->meta->table) %>;
     % }
    prov:wasDerivedFrom <<%= current_resource %>>.
 

--- a/lib/Tuba/files/templates/file/object.ttl.tut
+++ b/lib/Tuba/files/templates/file/object.ttl.tut
@@ -1,29 +1,18 @@
 % layout 'default', namespaces => [qw/dcterms dbpedia dbpedia_owl xsd schema fabio/];
+%= filter_lines_with empty_predicate() => begin
 
 <<%= current_resource %>>
    dcterms:identifier "<%= $file->identifier %>";
-%#   dbpedia:Path_(computing) "<%= tl($file->file) %>";
-
-% if ($file->location) {
+%#    dbpedia:Path_(computing) "<%= tl($file->file) %>";
    dbpedia:Domain_Name "<%= url_host($file->location) %>";
-% }
-
-## The SHA-1 hash pertaining to the file
-% if ($file->identifier) {
    dbpedia:SHA-1 "<%= $file->sha1 %>";
-% }
-
-## File Size (bytes):
+   dbpedia:MIME "<%= $file->mime_type %>";
    dbpedia_owl:fileSize "<%= $file->size %>"^^xsd:double;
-
-## MIME Type
-   dbpedia:MIME "<%= tl($file->mime_type) %>";
-
-## This file is associated with the following publication:
 % if (my @pubs = $file->publications) {
    % for my $file (@pubs) {
    schema:isRelatedTo <<%= obj_uri_for($file->to_object)->to_abs %>>;
-  % }
+   % }
 % }
-
    a fabio:ComputerFile .
+
+% end

--- a/lib/Tuba/files/templates/image/object.ttl.tut
+++ b/lib/Tuba/files/templates/image/object.ttl.tut
@@ -8,9 +8,6 @@
    dcterms:created "<%= $image->create_dt %>"^^xsd:dateTime;
    dcterms:dateSubmitted "<%= $image->submission_dt %>"^^xsd:date;
 
-## Image Attributes
-   dcterms:subject "<%= $image->attributes %>"^^xsd:string;
-
 ## Geographical extent of the image content
    gcis:northBoundLatitude "<%= $image->lat_max %>"^^xsd:float;
    gcis:southBoundLatitude "<%= $image->lat_min %>"^^xsd:float;
@@ -41,4 +38,3 @@
 %# % for my $keyword ($image->keywords) {
 %#   gcis:subject "<%== $keyword->stringify %>"^^xsd:string;
 %# % }
-

--- a/lib/Tuba/files/templates/instrument/object.ttl.tut
+++ b/lib/Tuba/files/templates/instrument/object.ttl.tut
@@ -4,8 +4,8 @@
    dcterms:identifier "<%= $instrument->platform_type_identifier %>";
    dcterms:title "<%= $instrument->name %>"^^xsd:string;
    dcterms:description "<%= $instrument->description %>"^^xsd:string;
-<% for my $platform ($instrument->platforms) { %>
+% for my $platform ($instrument->platforms) {
    gcis:inPlatform <<%= obj_uri_for($platform)->to_abs %>>;
-   <% } %>
+% }
 
    a gcis:Instrument .

--- a/lib/Tuba/files/templates/platform/object.ttl.tut
+++ b/lib/Tuba/files/templates/platform/object.ttl.tut
@@ -1,4 +1,5 @@
 % layout 'default', namespaces => [qw/dcterms xsd dbpprop gcis/];
+%= filter_lines_with empty_predicate() => begin
 
 <<%= current_resource %>>
    dcterms:identifier "<%= $platform->platform_type_identifier %>";
@@ -6,10 +7,11 @@
    dcterms:description "<%= $platform->description %>"^^xsd:string;
    gcis:hasURL "<%= $platform->url %>"^^xsd:anyURI;
    dcterms:type "<%= $platform->type %>";
-   dbpprop:launchDate "<%= $platform->start_date %>"^^xsd:date;
-   dbpprop:deactivated "<%= $platform->end_date %>"^^xsd:date;
-<% for my $instrument ($platform-instruments) { %>
+   dbpprop:launchDate "<%= $platform->start_date %>"^^xsd:dateTime;
+   dbpprop:deactivated "<%= $platform->end_date %>"^^xsd:dateTime;
+% for my $instrument ($platform-instruments) {
    gcis:hasInstrument <<%= obj_uri_for($instrument)->to_abs %>>;
-   <% } %>
+% }
 
    a gcis:Platform .
+% end

--- a/lib/Tuba/files/templates/reference/object.ttl.tut
+++ b/lib/Tuba/files/templates/reference/object.ttl.tut
@@ -1,4 +1,4 @@
-% layout 'default', namespaces => [qw/dcterms biro gcis/];
+% layout 'default', namespaces => [qw/dcterms biro/];
 
 <<%= current_resource %>>
    dcterms:identifier "<%= $reference->identifier %>";

--- a/lib/Tuba/files/templates/table/object.ttl.tut
+++ b/lib/Tuba/files/templates/table/object.ttl.tut
@@ -7,7 +7,7 @@
    gcis:tableNumber "<%= $chapter->number %>.<%= $table->ordinal %>"^^xsd:float;
 % }
    dcterms:title "<%= no_tbibs($table->title) %>"^^xsd:string;
-   gcis:hasCaption "<%= no_tbibs($table->caption) %>"^^xsd:string; 
+   gcis:hasCaption """<%= no_tbibs($table->caption) %>"""^^xsd:string;
 
 % if (my $chapter = ( (stash 'chapter') || $table->chapter)) {
    gcis:isTableOf <<%= uri($chapter) %>>;
@@ -19,7 +19,7 @@
 % }
 
 % for my $keyword ($table->keywords) {
-## Keywords associated with table   
+## Keywords associated with table
    gcis:subject "<%== $keyword->stringify %>"^^xsd:string;
 % }
 

--- a/lib/Tuba/files/templates/webpage/object.ttl.tut
+++ b/lib/Tuba/files/templates/webpage/object.ttl.tut
@@ -5,7 +5,7 @@
    dcterms:identifier "<%= $webpage->identifier %>";
    dcterms:title "<%= $webpage->title %>"^^xsd:string;
    gcis:hasURL "<%= $webpage->url %>"^^xsd:anyURI;
-   dcterms:date "<%= $webpage->access_date %>"^^xsd:date;
+   dcterms:date "<%= $webpage->access_date %>"^^xsd:dateTime;
 
    a bibo:Webpage.
 


### PR DESCRIPTION
replaced xsd:date with xsd:datetime for dates in turtle for platforms

removed unecessary bracket in turtle for instruments

replaced $r with $foo in dataset/prov.ttl.tut

changed caption to long-literal in turtle for tables

added long literals to turtle for datasets

added long literals to turtle for book

added tl helper to title in webpage

changed xsd:date to xsd:dateTime for access_date in webpage

removed gcis namespace from turtle for references

added space in file turtle to undirty working tree and permit push
SPARQL-related changes to turtle formatting

removed extra whitespace for table caption

removed extra whitespace for table caption
