### PR TITLE
added """ to report titles

### DIFF
--- a/lib/Tuba/files/templates/report/object.ttl.tut
+++ b/lib/Tuba/files/templates/report/object.ttl.tut
@@ -3,7 +3,7 @@
 
 <<%= current_resource %>>
    dcterms:identifier "<%= $report->identifier %>";
-   dcterms:title "<%= $report->title %>"^^xsd:string;
+   dcterms:title """<%= $report->title %>"""^^xsd:string;
    dwc:year "<%= $report->publication_year %>"^^xsd:gYear;
 % if ($report->doi) {
    bibo:doi "<%= $report->doi %>";


### PR DESCRIPTION
Rationale: a few, but not all, report titles extend onto two turtle lines.
