### PR TITLE
integrated skos terms into turtle for lexicons (formerly #69)

### DIFF
--- a/lib/Tuba/files/templates/lexicon/object.ttl.tut
+++ b/lib/Tuba/files/templates/lexicon/object.ttl.tut
@@ -1,10 +1,10 @@
-% layout 'default', namespaces => [qw/dcterms xsd gcis prov lemon dbpedia/];
+% layout 'default', namespaces => [qw/dcterms xsd gcis skos/];
 
 <<%= current_resource %>>
    dcterms:identifier "<%= $lexicon->identifier %>";
    dcterms:title "<%= $lexicon->description %>"^^xsd:string;
    gcis:hasURL "<%= $lexicon->url %>"^^xsd:anyURI;
 
-   a dbpedia:Lexicon .
+   a skos:Concept .
 
 %= include 'representation';

--- a/lib/Tuba/files/templates/representation.ttl.tut
+++ b/lib/Tuba/files/templates/representation.ttl.tut
@@ -3,8 +3,8 @@
 % my $terms = orm->{exterm}{mng}->get_objects(query => [lexicon_identifier => $lexicon->identifier, context => $context]);
       % for my $term (@$terms) {
 <<%= $term->gcid %>>
-   a lemon:representation;
-   prov:wasDerivedFrom "<%= $term->term %>".
+   a skos:Concept;
+   skos:altLabel "<%= $term->term %>".
 
       % }
 


### PR DESCRIPTION
replaced lemon namespace with skos namespace in turtle for lexicons

removed prov namespace from turtle for lexicons
