### PR TITLE
Various misc. changes

### DIFF
--- a/lib/Tuba/files/templates/dataset/object.ttl.tut
+++ b/lib/Tuba/files/templates/dataset/object.ttl.tut
@@ -1,4 +1,4 @@
-% layout 'default', namespaces => [qw/datacite dcterms xsd dwc gcis cito dcat prov dbpedia/];
+% layout 'default', namespaces => [qw/datacite dcterms xsd dwc gcis cito dcat prov dbpedia skos/];
 %= filter_lines_with empty_predicate() => begin
 %#
 <<%= current_resource %>>
@@ -41,3 +41,4 @@
 
 %= include 'prov';
 %= include 'contributors';
+%= include 'other_identifiers';

--- a/lib/Tuba/files/templates/instrument/object.ttl.tut
+++ b/lib/Tuba/files/templates/instrument/object.ttl.tut
@@ -1,4 +1,5 @@
-% layout 'default', namespaces => [qw/dcterms xsd gcis prov/];
+% layout 'default', namespaces => [qw/dcterms xsd gcis prov skos/];
+%= filter_lines_with empty_predicate() => begin
 %#
 <<%= current_resource %>>
    dcterms:identifier "<%= $instrument->identifier %>";
@@ -9,4 +10,7 @@
    dcterms:description "<%= $instrument->description %>"^^xsd:string;
    a gcis:Instrument .
 
+% end
+
 %= include 'contributors';
+%= include 'other_identifiers';

--- a/lib/Tuba/files/templates/instrument_instance/object.ttl.tut
+++ b/lib/Tuba/files/templates/instrument_instance/object.ttl.tut
@@ -2,11 +2,11 @@
 %#
 <<%= current_resource %>>
    dcterms:identifier "<%= $instrument_instance->identifier %>";
-% for my $platform ($instrument_instance->platforms) %>
+% for my $platform ($instrument_instance->platform_identifier) %>
    gcis:Platform <<%= uri($platform) %>>;
 } %
 %#
-% for my $instrument ($instrument_instance->instruments) %>
+% for my $instrument ($instrument_instance->instrument_identifier) %>
    gcis:Instrument <<%= uri($instrument) %>>;
 } %
 %#

--- a/lib/Tuba/files/templates/lexicon/object.ttl.tut
+++ b/lib/Tuba/files/templates/lexicon/object.ttl.tut
@@ -1,10 +1,10 @@
-% layout 'default', namespaces => [qw/dcterms xsd gcis prov lemon dbpedia/];
+% layout 'default', namespaces => [qw/dcterms xsd gcis skos/];
 
 <<%= current_resource %>>
    dcterms:identifier "<%= $lexicon->identifier %>";
    dcterms:title "<%= $lexicon->description %>"^^xsd:string;
    gcis:hasURL "<%= $lexicon->url %>"^^xsd:anyURI;
 
-   a dbpedia:Lexicon .
+   a skos:Concept .
 
 %= include 'representation';

--- a/lib/Tuba/files/templates/organization/object.ttl.tut
+++ b/lib/Tuba/files/templates/organization/object.ttl.tut
@@ -48,3 +48,4 @@
 % end
 
 %= include 'organization/contributors';
+%= include 'other_identifiers';

--- a/lib/Tuba/files/templates/platform/object.ttl.tut
+++ b/lib/Tuba/files/templates/platform/object.ttl.tut
@@ -1,4 +1,4 @@
-% layout 'default', namespaces => [qw/dcterms xsd dbpprop gcis prov/];
+% layout 'default', namespaces => [qw/dcterms xsd dbpprop gcis prov skos/];
 %= filter_lines_with empty_predicate() => begin
 %#
 <<%= current_resource %>>
@@ -18,3 +18,4 @@
 
 
 %= include 'contributors';
+%= include 'other_identifiers';

--- a/lib/Tuba/files/templates/representation.ttl.tut
+++ b/lib/Tuba/files/templates/representation.ttl.tut
@@ -3,8 +3,8 @@
 % my $terms = orm->{exterm}{mng}->get_objects(query => [lexicon_identifier => $lexicon->identifier, context => $context]);
       % for my $term (@$terms) {
 <<%= $term->gcid %>>
-   a lemon:representation;
-   prov:wasDerivedFrom "<%= $term->term %>".
+   a skos:Concept;
+   skos:altLabel "<%= $term->term %>".
 
       % }
 

--- a/lib/Tuba/files/templates/table/object.ttl.tut
+++ b/lib/Tuba/files/templates/table/object.ttl.tut
@@ -4,7 +4,11 @@
 <<%= current_resource %>>
    dcterms:identifier "<%= $table->identifier %>";
 % if (my $chapter = ( (stash 'chapter') || $table->chapter)) {
-   gcis:tableNumber "<%= $chapter->number %>.<%= $table->ordinal %>"^^xsd:string;
+   % if ($chapter->number eq "") {
+   gcis:tableNumber "<%= $table->ordinal %>"^^xsd:string;
+   % } else {
+        gcis:tableNumber "<%= $chapter->number %>.<%= $table->ordinal %>"^^xsd:string;
+   % }
 % }
    dcterms:title "<%= no_tbibs($table->title) %>"^^xsd:string;
    gcis:hasCaption "<%= no_tbibs($table->caption) %>"^^xsd:string;


### PR DESCRIPTION
replaced lemon namespace with skos namespace in turtle for lexicons

removed prov namespace from turtle for lexicons

changed methods called for instrument_instances

added conditionality on gcis:TableNumber

added conditionality to lines of turtle for instruments

further adjusted aforementioned commit to turtle for tables

other_identifiers to turtle for datasets

other_identifiers to turtle for instruments

other_identifiers to turtle for platforms

other_identifiers to turtle for orgs

Revert "further adjusted aforementioned commit to turtle for tables"

This reverts commit 8da0cc45b6fffcf4a44200c48188053272a64ebe.
