### PR TITLE
"Also known as" for platforms, instruments, and datasets

### DIFF
--- a/lib/Tuba/files/templates/dataset/object.ttl.tut
+++ b/lib/Tuba/files/templates/dataset/object.ttl.tut
@@ -41,3 +41,4 @@
 
 %= include 'prov';
 %= include 'contributors';
+%= include 'other_identifiers', gcid => $dataset->uri($self);

--- a/lib/Tuba/files/templates/instrument/object.ttl.tut
+++ b/lib/Tuba/files/templates/instrument/object.ttl.tut
@@ -12,4 +12,6 @@
 
 % end
 
+
 %= include 'contributors';
+%= include 'other_identifiers', gcid => $instrument->uri($self);

--- a/lib/Tuba/files/templates/other_identifiers.ttl.tut
+++ b/lib/Tuba/files/templates/other_identifiers.ttl.tut
@@ -1,0 +1,18 @@
+% my $matches = orm->{'exterm'}{mng}->get_objects(
+%   query => [ gcid => "$gcid" ],
+%   sort_by => "lexicon_identifier, term"
+% );
+%#
+% if (@$matches) {
+## Also known as:
+    % for my $exterm (@$matches) {
+<<%= current_resource %>>
+      % if (my $url = $exterm->native_url) {
+   skos:altLabel "<%= $exterm->term %>";
+   gcis:hasURL "<%= $url %>";
+      % } else {
+   skos:altLabel <%= $exterm->term %>;
+      % }
+   skos:Concept <<%= uri($exterm->lexicon) %>>.
+    % }
+% }

--- a/lib/Tuba/files/templates/platform/object.ttl.tut
+++ b/lib/Tuba/files/templates/platform/object.ttl.tut
@@ -18,3 +18,4 @@
 
 
 %= include 'contributors';
+%= include 'other_identifiers', gcid => $platform->uri($self);


### PR DESCRIPTION
added "also known as" template to turtle for platforms

added "also known as" template to turtle for instruments

created other_identifiers.ttl.tut
"Also known as" for platforms, instruments, and datasets
