### PR TITLE
Deleted empty table and caption tags from thumbs.html.ep

### DIFF
--- a/lib/Tuba/files/templates/thumbs.html.ep
+++ b/lib/Tuba/files/templates/thumbs.html.ep
@@ -8,9 +8,6 @@
 
 %= include 'list_formats';
 
-<table class='table table-condensed table-bordered table-striped'>
-<caption>
-</caption>
 % my @clone = @$objects;
 
 % if (my $page = stash 'page') {


### PR DESCRIPTION
This table tag and caption tags were also causing the sticky footer to not work correctly in Chrome.