### PR TITLE
Deleted padding-top rule for #footer div.

### DIFF
--- a/lib/Tuba/files/public/css/gcis.css
+++ b/lib/Tuba/files/public/css/gcis.css
@@ -10,7 +10,6 @@ html, body {
 }
 #footer {
 	margin: -55px auto 0 auto;
-	padding-top: 15px;
 	position: relative;
 	height: 55px;
 	clear: both;


### PR DESCRIPTION
This fixes the scroll bar being displayed on all pages in Firefox.