### PR TITLE
added qualifiedAssociation for software agent

### DIFF
--- a/lib/Tuba/files/templates/activity/object.ttl.tut
+++ b/lib/Tuba/files/templates/activity/object.ttl.tut
@@ -1,4 +1,4 @@
-% layout 'default', namespaces => [qw/dcterms xsd prov dbpedia_owl gcis meth rdf/];
+% layout 'default', namespaces => [qw/dcterms xsd prov dbpedia_owl gcis meth rdf rdfs/];
 %= filter_lines_with empty_predicate() => begin
 %#
 <<%= current_resource %>>

--- a/lib/Tuba/files/templates/activity/object.ttl.tut
+++ b/lib/Tuba/files/templates/activity/object.ttl.tut
@@ -15,14 +15,24 @@
 ## Output datafiles   
    dbpedia_owl:filename "<%= $activity->output_artifacts %>"^^xsd:string;
 
-## Software utilized
-   gcis:Software "<%= $activity->software %>"^^xsd:string;
-
 ## Computing environment
    dcterms:InteractiveResource "<%= $activity->computing_environment %>"^^xsd:string;
+   
+## assignment of responsibility to an agent for an activity, indicating that the agent 
+## had a role in the activity. It further allows for a plan to be specified, which is
+## the plan intended by the agent to achieve some goals in the context of this activity.
 
-## Methodology employed
-   meth:Methodology "<%= $activity->methodology %>"^^xsd:string;
+   prov:qualifiedAssociation [
+      a prov:QualifiedAssociation ;
+      prov:agent [
+         a prov:SoftwareAgent, gcis:Software ;
+         rdfs:label "<%= $activity->software %>"^^xsd:string;
+      ] ;
+      prov:hadPlan [
+         a prov:Plan, meth:Methodology ;
+         rdf:value "<%= $activity->methodology %>"^^xsd:string;
+      ] ;
+   ] ;
 
    a prov:Activity .
 


### PR DESCRIPTION
Updated template to create a qualified association for the software agent and methodology employed in this activity.

Fixes USGCRP/gcis-ontology/issues/9.

note - I know we are probably not ready to merge this pull request yet.  I am creating it so we can see what the changes to the template would look like and discuss.