### PR TITLE
update datacite:AlternateResourceIdentifier usage

### DIFF
--- a/lib/Tuba/files/templates/dataset/object.ttl.tut
+++ b/lib/Tuba/files/templates/dataset/object.ttl.tut
@@ -1,4 +1,4 @@
-% layout 'default', namespaces => [qw/datacite dcterms xsd dwc gcis cito dcat prov skos/];
+% layout 'default', namespaces => [qw/datacite dcterms xsd dwc gcis cito dcat prov skos rdf/];
 %= filter_lines_with empty_predicate() => begin
 %#
 <<%= current_resource %>>
@@ -7,7 +7,7 @@
    dwc:year "<%= $dataset->publication_year %>"^^xsd:gYear;
    dcterms:hasVersion "<%= $dataset->version %>";
    datacite:doi "<%= $dataset->doi %>";
-   datacite:AlternateResourceIdentifier "<%= $dataset->native_id %>";
+   datacite:hasIdentifier [ a datacite:AlternateResourceIdentifier; rdf:value "<%= $dataset->native_id %>" ] ;
    gcis:accessURL "<%= $dataset->url %>"^^xsd:anyURI;
    cito:citesAsMetadataDocument "<%= $dataset->cite_metadata %>";
    dcterms:description "<%= no_tbibs($dataset->description) %>"^^xsd:string;


### PR DESCRIPTION
based on http://www.essepuntato.it/lode/http://purl.org/spar/datacite#introduction the property to reference a datacite:AlternateResourceIdentifier would be datacite:hasIdentifier.

We can optionally include a datacite:usesIdentifierScheme here if one is known.