### PR TITLE
Added doi to turtle for chapters

### DIFF
--- a/lib/Tuba/files/templates/chapter/object.ttl.tut
+++ b/lib/Tuba/files/templates/chapter/object.ttl.tut
@@ -1,4 +1,4 @@
-% layout 'default', namespaces => [qw/dcterms xsd gcis cito biro prov/];
+% layout 'default', namespaces => [qw/dcterms xsd bibo gcis cito biro prov/];
 %= filter_lines_with empty_predicate() => begin
 %#  
 <<%= current_resource %>>

--- a/lib/Tuba/files/templates/chapter/object.ttl.tut
+++ b/lib/Tuba/files/templates/chapter/object.ttl.tut
@@ -5,6 +5,7 @@
    dcterms:identifier "<%= $chapter->identifier %>";
    gcis:chapterNumber "<%= $chapter->number %>"^^xsd:integer;
    dcterms:title "<%= $chapter->title %>"^^xsd:string;
+   bibo:doi "<%= $chapter->doi %>";
    gcis:hasURL "<%= $chapter->url %>"^^xsd:anyURI;
    gcis:isChapterOf <<%= uri($report) %>>;
  


### PR DESCRIPTION
Note: I recognize that the presence of bibo:doi could make gcis:hasURL redundant.  However, this isn't trivial for the NCA3 since the url directs one to the web version of that document, while the other to the download page.  (Fine with me, of course).  Of course this won't hold true for all "chapters" in GCIS.  If including both "doi" and "hasURL" is problematic, let me know and I'll create an issue in gethub.