### PR TITLE
Called out Stephan

### DIFF
--- a/lib/Tuba/files/templates/doc/about.html.ep
+++ b/lib/Tuba/files/templates/doc/about.html.ep
@@ -64,7 +64,7 @@ Justin Goldstein : Researcher
 Robert Wolfe : Project Manager
 Amanda McQueen, Brent Newman : GCIS Interns
 Tania Sizer : Web Designer
-Xiagoang (Marshall) Ma, Peter Fox and the team at the <a href="http://tw.rpi.edu/web/project/gcis-imsap">Tetherless World Constellation</a> : Ontology Engineering.</p>
+Xiagoang (Marshall) Ma, Stephan Zednik, Peter Fox and the team at the <a href="http://tw.rpi.edu/web/project/gcis-imsap">Tetherless World Constellation</a> : Ontology Engineering.</p>
 
 <h4>GCIS Version</h4>
 <p><%= $Tuba::VERSION %></p>


### PR DESCRIPTION
Given that Stephan, like Marshall, has led the ontology development efforts, we should call him out as well.