### PR TITLE
Turtle for role_types

### DIFF
--- a/lib/Tuba/files/templates/role_type/object.ttl.tut
+++ b/lib/Tuba/files/templates/role_type/object.ttl.tut
@@ -1,0 +1,10 @@
+% layout 'default', namespaces => [qw/dcterms prov/];
+%= filter_lines_with empty_predicate() => begin
+%#
+<<%= current_resource %>>
+   dcterms:identifier "<%= $role_type->identifier %>";
+   prov:label "<%= $role_type->label %>";
+
+   a prov:Role .
+   
+% end


### PR DESCRIPTION
Basic turtle, can expand later.  Replaces current template which ends in a semicolon.