### PR TITLE
Initial turtle for keywords

### DIFF
--- a/lib/Tuba/files/templates/gcmd_keyword/object.ttl.tut
+++ b/lib/Tuba/files/templates/gcmd_keyword/object.ttl.tut
@@ -1,0 +1,13 @@
+% layout 'default', namespaces => [qw/dcterms rdfs xsd dbpedia/];
+%= filter_lines_with empty_predicate() => begin
+%#
+<<%= current_resource %>>
+   dcterms:identifier "<<%= $gcmd_keyword->identifier %>";
+   rdfs:label "<<%= $gcmd_keyword->label %>"^^xsd:string;
+   
+   a dbpedia:Index_term .
+
+% end
+
+
+%= include 'prov';

--- a/lib/Tuba/files/templates/gcmd_keyword/object.ttl.tut
+++ b/lib/Tuba/files/templates/gcmd_keyword/object.ttl.tut
@@ -2,8 +2,8 @@
 %= filter_lines_with empty_predicate() => begin
 %#
 <<%= current_resource %>>
-   dcterms:identifier "<<%= $gcmd_keyword->identifier %>";
-   rdfs:label "<<%= $gcmd_keyword->label %>"^^xsd:string;
+   dcterms:identifier "<%= $gcmd_keyword->identifier %>";
+   rdfs:label "<%= $gcmd_keyword->label %>"^^xsd:string;
    
    a dbpedia:Index_term .
 

--- a/lib/Tuba/files/templates/gcmd_keyword/object.ttl.tut
+++ b/lib/Tuba/files/templates/gcmd_keyword/object.ttl.tut
@@ -4,6 +4,7 @@
 <<%= current_resource %>>
    dcterms:identifier "<%= $gcmd_keyword->identifier %>";
    rdfs:label "<%= $gcmd_keyword->label %>"^^xsd:string;
+   dcterms:description "<%= $gcmd_keyword->definition %>"^^xsd:string;
    
    a dbpedia:Index_term .
 


### PR DESCRIPTION
Took an initial stab so that the turtle for GCMD_keywords reads in a grammatically correct manner.  Development will be ongoing.