### PR TITLE
gcis:Article -> gcis:AcademicArticle

### DIFF
--- a/lib/Tuba/files/templates/article/object.ttl.tut
+++ b/lib/Tuba/files/templates/article/object.ttl.tut
@@ -14,7 +14,7 @@
    gcis:hasURL "<%= $article->url %>"^^xsd:anyURI;
 % }
 
-   a gcis:Article .
+   a gcis:AcademicArticle .
 % end
 
 


### PR DESCRIPTION
In order to accommodate the change from gcis:Article to gcis:AcademicArticle in the Ontology.  See:
https://github.com/USGCRP/gcis-ontology/pull/65