### PR TITLE
Removed dcterms:bibliographicCitation

### DIFF
--- a/lib/Tuba/files/templates/reference/object.ttl.tut
+++ b/lib/Tuba/files/templates/reference/object.ttl.tut
@@ -15,4 +15,4 @@
    biro:isReferencedBy <<%= uri($chapter) %>>;
 % }
 
-   a biro:BibliographicRecord, dcterms:bibliographicCitation .
+   a biro:BibliographicRecord .


### PR DESCRIPTION
Removed due to it being a property in-lieu of a class.