### PR TITLE
prov:wasDerivedFrom->cito:cites

### DIFF
--- a/lib/Tuba/files/templates/prov.ttl.tut
+++ b/lib/Tuba/files/templates/prov.ttl.tut
@@ -44,7 +44,7 @@
    prov:wasGeneratedBy <<%= uri($parent->{activity}) %>>;
           % }
           % if ($parent->{publication}) {
-   prov:wasDerivedFrom <<%= uri($parent->{publication}->to_object) %>>.
+   cito:cites <<%= uri($parent->{publication}->to_object) %>>.
           % }
 
     % }


### PR DESCRIPTION
to be consistent with terminology in the html.