### PR TITLE
add type prov:Agent to instrument instances

### DIFF
--- a/lib/Tuba/files/templates/instrument_instance/object.ttl.tut
+++ b/lib/Tuba/files/templates/instrument_instance/object.ttl.tut
@@ -1,4 +1,4 @@
-% layout 'default', namespaces => [qw/dcterms gcis/];
+% layout 'default', namespaces => [qw/dcterms prov gcis/];
 
 <<%= current_resource %>>
 % for my $platform ($instrument_instance->platform) {
@@ -13,4 +13,4 @@
    prov:contributed <<%= uri($measurement->dataset) %>>;
 % }
 
-   a gcis:Instrument .
+   a gcis:Instrument, prov:Agent .


### PR DESCRIPTION
references USGCRP/gcis-ontology/issues/124.

This type is inferable from the domain of prov:contributed; adding it to the template to make the type information explicit without requiring reasoning.