### PR TITLE
remove type dbpedia:Lexicon

### DIFF
--- a/lib/Tuba/files/templates/lexicon/object.ttl.tut
+++ b/lib/Tuba/files/templates/lexicon/object.ttl.tut
@@ -5,6 +5,6 @@
    dcterms:title "<%= $lexicon->description %>"^^xsd:string;
    gcis:hasURL "<%= $lexicon->url %>"^^xsd:anyURI;
 
-   a skos:ConceptScheme, dbpedia:Lexicon .
+   a skos:ConceptScheme .
 
 %= include 'representation';


### PR DESCRIPTION
Mentioned in USGCRP/gcis-ontology/issues/35, dbpedia:Lexicon is not a class but an instance and should not be used a type.