### PR TITLE
clarified question

### DIFF
--- a/lib/Tuba/Doc.pm
+++ b/lib/Tuba/Doc.pm
@@ -23,7 +23,7 @@ sub examples {
 where { ?s a gcis:Figure }
 limit 10",
         },
-        { desc => "List all of the findings from the Third National Climate Assessment.",
+        { desc => "List all of the chapter findings from the Third National Climate Assessment.",
           code => <<'SPARQL',
 
 PREFIX dcterms: <http://purl.org/dc/terms/>


### PR DESCRIPTION
The NCA3 has findings that are chapter-based and those of the report as a whole.  Clarified that the query returns only those which are chapter-based.  See also #233.