### PR TITLE
update predicates and type for model run output RDF

### DIFF
--- a/lib/Tuba/files/templates/model_run/object.ttl.tut
+++ b/lib/Tuba/files/templates/model_run/object.ttl.tut
@@ -1,4 +1,4 @@
-% layout 'default', namespaces => [qw/dcterms bibo gcis skos/];
+% layout 'default', namespaces => [qw/dcterms bibo gcis prov skos/];
 %= filter_lines_with empty_predicate() => begin
 %#
 <<%= current_resource %>>

--- a/lib/Tuba/files/templates/model_run/object.ttl.tut
+++ b/lib/Tuba/files/templates/model_run/object.ttl.tut
@@ -4,16 +4,16 @@
 <<%= current_resource %>>
    dcterms:identifier "<%= $model_run->stringify %>";
    bibo:doi "<%= $model_run->doi %>";
-   gcis:Model <<%= uri($model_run->model) %>>;
+   gcis:sourceModel <<%= uri($model_run->model) %>>;
    gcis:Scenario <<%= uri($model_run->scenario) %>>;
-   gcis:Project <<%= uri($model_run->project) %>>;
+   gcis:relatedProject <<%= uri($model_run->project) %>>;
    gcis:hasSpatialResolution "<%= $model_run->spatial_resolution %>";
    gcis:hasTemporalResolution "<%= human_duration($model_run->time_resolution) %>";
 % if (my $activity = $model_run->activity) {
-   gcis:Activity <<%= uri($model_run->activity) %>>;
+   prov:wasGeneratedBy <<%= uri($model_run->activity) %>>;
 % }
 
-   a gcis:ModelRun .
+   a gcis:ModelRunOutput .
 % end
 
 


### PR DESCRIPTION
I think we may want to add a property to the ontology for the model scenario 

``<<%= uri($model_run->scenario) %>>``

The only scenario properties in the ontology are
```
gcis:Scenario a owl:Class ;
	rdfs:label "Scenario" ;
	rdfs:comment "Sets of assumptions used to help understand potential future conditions such as population growth, land use, and sea level rise. Scenarios are neither predictions nor forecasts. Scenarios are commonly used for planning purposes." ;
	rdfs:subClassOf prov:Entity .
	
gcis:describesScenario a owl:ObjectProperty ;
	rdfs:label "describes scenario" ;
	rdfs:comment "A resource may describe one or more scenarios." ;
	rdfs:range gcis:Scenario ;
	owl:inverseOf gcis:scenarioDescribedIn .

gcis:scenarioDescribedIn a owl:ObjectProperty ;
	rdfs:label "is described in" ;
	rdfs:comment "A scenario is described in a resource." ;
	rdfs:domain gcis:Scenario .
```
and I am not sure if ``gcis:describesScenario`` is the correct property to use here.