### PR TITLE
Permit website hosts to show up

### DIFF
--- a/lib/Tuba/files/templates/webpage/object.html.ep
+++ b/lib/Tuba/files/templates/webpage/object.html.ep
@@ -16,6 +16,10 @@
 % }
 
     <div class='row well'>
+
+# Next command adds host
+%= include 'h/contributors_short', object => $webpage, role_regex => '(editor|author|distributor|data_producer|contributing_agency|publisher|host)';
+
         <div class='pull-right col-lg-4 col-md-4 col-sm-4 col-xs-4' style='top:2px;text-align:right;'>
         % my $pub = $webpage->get_publication;
         % if ($pub) {


### PR DESCRIPTION
Allows the host of the website to show up in the html.  Earlier this was restricted to reports, not websites.