### PR TITLE
Added "center of"

### DIFF
--- a/db/patches/2190_morerels.sql
+++ b/db/patches/2190_morerels.sql
@@ -1,0 +1,2 @@
+insert into organization_relationship (identifier, label)
+values ('center_of', 'center of')


### PR DESCRIPTION
Builds on patches 0780 and 0830.

Rationale: feedback that university institutes should really be "centers of" instead of "program of."