### PR TITLE
Associated journals with contributors

### DIFF
--- a/lib/Tuba/files/templates/journal/object.ttl.tut
+++ b/lib/Tuba/files/templates/journal/object.ttl.tut
@@ -16,3 +16,5 @@
    a gcis:Journal, fabio:Journal .
 
 % end
+
+%= include 'contributors';


### PR DESCRIPTION
We would like one to be able to query journal publishers using SPARQL since various journal publishers appear in GCIS as affiliations for article authors (e.g. ESA for "Ecological Applications" and others) The necessary code is found in contributors.ttl.tut which had previously not been invoked in /journal/object.ttl.tut