### PR TITLE
Lock Mojo Version <= 6.24

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -40,10 +40,11 @@ my $builder = Module::Build::Database->new(
     dist_abstract       => "The Useful Backend API",
     release_status      => 'stable',
     configure_requires => {
-        'Module::Build' => 0.39,
-        'Module::Build::Mojolicious' => 0,
+        'Module::Build' => '0.39',
+        #'Module::Build::Mojolicious' => 0,  #commented out, dependency inteferes with Mojolicous version -rs
         'Module::Build::Database' => 0,
-        'Mojolicious::Plugin::InstallablePaths' => 0,
+        'Mojolicious' => '>= 6.08, <= 6.24',
+        #'Mojolicious::Plugin::InstallablePaths' => 0, #commented out, dependency inteferes with Mojolicous version
     },
     build_requires => {
         'Test::More' => 0,
@@ -54,7 +55,7 @@ my $builder = Module::Build::Database->new(
         'LWP::UserAgent' => 0,
         'Number::Bytes::Human' => 0,
         'Mojolicious::Plugin::YamlConfig' => 0,
-        'Mojolicious' => '6.08',
+        'Mojolicious' => '>= 6.08, <= 6.24',
         'Number::Format' => 0,
         'YAML::Syck'  => 0,
         'YAML::XS'    => 0,

--- a/META.json
+++ b/META.json
@@ -4,7 +4,7 @@
       "unknown"
    ],
    "dynamic_config" : 1,
-   "generated_by" : "Module::Build version 0.421",
+   "generated_by" : "Module::Build version 0.4216",
    "license" : [
       "agpl_3"
    ],
@@ -25,8 +25,7 @@
          "requires" : {
             "Module::Build" : "0.39",
             "Module::Build::Database" : "0",
-            "Module::Build::Mojolicious" : "0",
-            "Mojolicious::Plugin::InstallablePaths" : "0"
+            "Mojolicious" : ">= 6.08, <= 6.24"
          }
       },
       "runtime" : {
@@ -48,7 +47,7 @@
             "JSON::XS" : "0",
             "LWP::UserAgent" : "0",
             "Lingua::EN::Inflect" : "0",
-            "Mojolicious" : "6.08",
+            "Mojolicious" : ">= 6.08, <= 6.24",
             "Mojolicious::Plugin::InstallablePaths" : "0",
             "Mojolicious::Plugin::YamlConfig" : "0",
             "Number::Bytes::Human" : "0",
@@ -350,5 +349,6 @@
       }
    },
    "release_status" : "stable",
-   "version" : "1.40"
+   "version" : "1.40",
+   "x_serialization_backend" : "JSON::PP version 2.27203"
 }

--- a/META.yml
+++ b/META.yml
@@ -9,10 +9,9 @@ build_requires:
 configure_requires:
   Module::Build: '0.39'
   Module::Build::Database: '0'
-  Module::Build::Mojolicious: '0'
-  Mojolicious::Plugin::InstallablePaths: '0'
+  Mojolicious: '>= 6.08, <= 6.24'
 dynamic_config: 1
-generated_by: 'Module::Build version 0.421, CPAN::Meta::Converter version 2.142690'
+generated_by: 'Module::Build version 0.4216, CPAN::Meta::Converter version 2.150005'
 license: open_source
 meta-spec:
   url: http://module-build.sourceforge.net/META-spec-v1.4.html
@@ -218,7 +217,7 @@ requires:
   JSON::XS: '0'
   LWP::UserAgent: '0'
   Lingua::EN::Inflect: '0'
-  Mojolicious: '6.08'
+  Mojolicious: '>= 6.08, <= 6.24'
   Mojolicious::Plugin::InstallablePaths: '0'
   Mojolicious::Plugin::YamlConfig: '0'
   Number::Bytes::Human: '0'
@@ -244,3 +243,4 @@ requires:
   YAML::Syck: '0'
   YAML::XS: '0'
 version: '1.40'
+x_serialization_backend: 'CPAN::Meta::YAML version 0.012'


### PR DESCRIPTION
This locks the Mojolicious version to the last known good version of 6.24 where builds did not fail Travis tests on (unmodified) Tuba.pm

Technically, the change allows for any version between 6.08 and 6.24, but cpanm always pulls the most recent version available/allowed.