### PR TITLE
Added condition for predecessor orgs

### DIFF
--- a/lib/Tuba/files/templates/organization/object.ttl.tut
+++ b/lib/Tuba/files/templates/organization/object.ttl.tut
@@ -34,10 +34,12 @@
         % ||  ($map->organization_relationship_identifier eq "working_group_of")
         % ||  ($map->organization_relationship_identifier eq "commission_of")) {
      org:unitOf <<%= uri($map->other_organization) %>> .
+        % } elsif ($map->organization_relationship_identifier eq "predecessor_of") {
+        prov:wasDerivedFrom <<%= uri($map->other_organization) %>> .
         % } else {
-     org:linkedTo <<%= uri($map->other_organization) %>> .
+        org:linkedTo <<%= uri($map->other_organization) %>> .
         % }
-     % }
+      % }
   % }
 % #
      % if (my @maps = $organization->organization_maps_objs) {
@@ -63,7 +65,9 @@
         % ||  ($map->organization_relationship_identifier eq "working_group_of")
         % ||  ($map->organization_relationship_identifier eq "commission_of")) {
      org:unitOf <<%= current_resource %>> .
-        % } else {
+        % } elsif ($map->organization_relationship_identifier eq "predecessor_of") {
+     prov:wasDerivedFrom <<%= uri($map->other_organization) %>> .
+      % } else {
      org:linkedTo <<%= current_resource %>> .
      % }
   %}

--- a/lib/Tuba/files/templates/organization/object.ttl.tut
+++ b/lib/Tuba/files/templates/organization/object.ttl.tut
@@ -35,9 +35,9 @@
         % ||  ($map->organization_relationship_identifier eq "commission_of")) {
      org:unitOf <<%= uri($map->other_organization) %>> .
         % } elsif ($map->organization_relationship_identifier eq "predecessor_of") {
-        prov:wasDerivedFrom <<%= uri($map->other_organization) %>> .
+     prov:wasDerivedFrom <<%= uri($map->other_organization) %>> .
         % } else {
-        org:linkedTo <<%= uri($map->other_organization) %>> .
+     org:linkedTo <<%= uri($map->other_organization) %>> .
         % }
       % }
   % }


### PR DESCRIPTION
See Section 2.4 at: https://www.w3.org/TR/vocab-org/ (last accessed 6/19/16).  The proper way to relate organizations to their predecessors is through "prov:wasDerivedAs."