### PR TITLE
Merge in display_name & description support

### DIFF
--- a/db/patches/2260_alter_pubs_desc_title.sql
+++ b/db/patches/2260_alter_pubs_desc_title.sql
@@ -4,9 +4,11 @@ alter table article add column description character varying;
 alter table webpage add column description character varying;
 alter table chapter add column description character varying;
 alter table journal add column description character varying;
+alter table book add column description character varying;
 
 
 comment on column "article".description is 'The abstract of the article, or a similar brief description.';
 comment on column "webpage".description is 'A brief description of the web page.';
 comment on column "chapter".description is 'A brief description of the chapter.';
 comment on column "journal".description is 'A brief description of the journal.';
+comment on column "book".description is 'A brief description of the book.';

--- a/db/patches/2260_alter_pubs_desc_title.sql
+++ b/db/patches/2260_alter_pubs_desc_title.sql
@@ -3,8 +3,10 @@
 alter table article add column description character varying;
 alter table webpage add column description character varying;
 alter table chapter add column description character varying;
+alter table journal add column description character varying;
 
 
 comment on column "article".description is 'The abstract of the article, or a similar brief description.';
 comment on column "webpage".description is 'A brief description of the web page.';
 comment on column "chapter".description is 'A brief description of the chapter.';
+comment on column "journal".description is 'A brief description of the journal.';

--- a/db/patches/2260_alter_pubs_desc_title.sql
+++ b/db/patches/2260_alter_pubs_desc_title.sql
@@ -1,0 +1,8 @@
+/* Extending some publication types to have a description & title column. See github gcis#369 */
+
+alter table article add column description character varying;
+alter table webpage add column description character varying;
+
+
+comment on column "article".description is 'The abstract of the article, or a similar brief description.';
+comment on column "webpage".description is 'A brief description of the web page.';

--- a/db/patches/2260_alter_pubs_desc_title.sql
+++ b/db/patches/2260_alter_pubs_desc_title.sql
@@ -2,7 +2,9 @@
 
 alter table article add column description character varying;
 alter table webpage add column description character varying;
+alter table chapter add column description character varying;
 
 
 comment on column "article".description is 'The abstract of the article, or a similar brief description.';
 comment on column "webpage".description is 'A brief description of the web page.';
+comment on column "chapter".description is 'A brief description of the chapter.';

--- a/lib/Tuba/Chapter.pm
+++ b/lib/Tuba/Chapter.pm
@@ -92,6 +92,7 @@ sub make_tree_for_show {
       url               => $chapter->url,
       doi               => $chapter->doi,
       title             => $chapter->title,
+      description       => $chapter->description,
       $c->common_tree_fields($chapter),
     };
 }

--- a/lib/Tuba/DB/Mixin/Object/Dataset.pm
+++ b/lib/Tuba/DB/Mixin/Object/Dataset.pm
@@ -1,0 +1,12 @@
+package Tuba::DB::Object::Dataset;
+# Tuba::DB::Mixin::Object::Dataset
+use Tuba::Util qw[new_uuid];
+use strict;
+
+sub stringify {
+    my $s = shift;
+    return $s->name;
+}
+
+1;
+

--- a/lib/Tuba/DB/Mixin/Object/Finding.pm
+++ b/lib/Tuba/DB/Mixin/Object/Finding.pm
@@ -2,6 +2,15 @@ package Tuba::DB::Object::Finding;
 # Tuba::DB::Mixin::Object::Finding;
 use strict;
 
+
+sub as_tree {
+    my $s = shift;
+    my $tree = $s->SUPER::as_tree(@_, deflate => 0);
+    $tree->{description} = $s->{statement};
+    return $tree;
+}
+
+
 sub numeric {
     my $s = shift;
     if (my $chapter = $s->chapter) {

--- a/lib/Tuba/DB/Mixin/Object/Generic.pm
+++ b/lib/Tuba/DB/Mixin/Object/Generic.pm
@@ -38,7 +38,7 @@ sub new_from_reference {
 
 sub as_tree {
     my $s = shift;
-    $tree = $s->SUPER::as_tree(@_, deflate => 0);
+    my $tree = $s->SUPER::as_tree(@_, deflate => 0);
     $tree->{description} = $s->stringify;
     return $tree;
 }

--- a/lib/Tuba/DB/Mixin/Object/Generic.pm
+++ b/lib/Tuba/DB/Mixin/Object/Generic.pm
@@ -39,7 +39,7 @@ sub new_from_reference {
 sub as_tree {
     my $s = shift;
     my $tree = $s->SUPER::as_tree(@_, deflate => 0);
-    $tree->{description} = $s->stringify;
+    $tree->{description} = $s->stringify(long => 1);
     return $tree;
 }
 
@@ -55,25 +55,30 @@ sub stringify {
         }
     }
 
-    my $long_name = '';
-    my $type = $s->attrs->{reftype};
-    if ($type)
-    {
-        $long_name .= $type . '. ';
+    if($args{long}){
+        my $long_name = '';
+        my $type = $s->attrs->{reftype};
+        if ($type)
+        {
+            $long_name .= $type . '. ';
+        }
+        my $date = $s->attrs->{Date};
+        if ($date)
+        {
+            $long_name .= $date . '. ';
+        }
+        my $author = $s->attrs->{Author};
+        if ($author) {
+            my @list = split /\x{d}/, $author;
+            $long_name .= $list[0];
+            $long_name =~ s/,.*$//;
+            $long_name .= ' et al.' if @list > 1;
+        }
+        return $long_name if length $long_name;
     }
-    my $date = $s->attrs->{Date};
-    if ($date)
-    {
-        $long_name .= $date . '. ';
-    }
-    my $author = $s->attrs->{Author};
-    if ($author) {
-        my @list = split /\x{d}/, $author;
-        $long_name .= $list[0];
-        $long_name =~ s/,.*$//;
-        $long_name .= ' et al.' if @list > 1;
-    }
-    return length $long_name ? $long_name : $uuid;
+
+    $title = $s->attrs->{Title};
+    return $title ? $title : $uuid;
 }
 
 

--- a/lib/Tuba/DB/Mixin/Object/Generic.pm
+++ b/lib/Tuba/DB/Mixin/Object/Generic.pm
@@ -73,7 +73,7 @@ sub stringify {
         $long_name =~ s/,.*$//;
         $long_name .= ' et al.' if @list > 1;
     }
-    return length $long_name ? $long_name :: $uuid;
+    return length $long_name ? $long_name : $uuid;
 }
 
 

--- a/lib/Tuba/DB/Mixin/Object/Generic.pm
+++ b/lib/Tuba/DB/Mixin/Object/Generic.pm
@@ -38,7 +38,9 @@ sub new_from_reference {
 
 sub as_tree {
     my $s = shift;
-    return $s->SUPER::as_tree(@_, deflate => 0);
+    $tree = $s->SUPER::as_tree(@_, deflate => 0);
+    $tree->{description} = $s->stringify;
+    return $tree;
 }
 
 

--- a/lib/Tuba/DB/Mixin/Object/Generic.pm
+++ b/lib/Tuba/DB/Mixin/Object/Generic.pm
@@ -77,7 +77,7 @@ sub stringify {
         return $long_name if length $long_name;
     }
 
-    $title = $s->attrs->{Title};
+    my $title = $s->attrs->{Title};
     return $title ? $title : $uuid;
 }
 

--- a/lib/Tuba/DB/Mixin/Object/Generic.pm
+++ b/lib/Tuba/DB/Mixin/Object/Generic.pm
@@ -41,6 +41,40 @@ sub as_tree {
     return $s->SUPER::as_tree(@_, deflate => 0);
 }
 
+
+sub stringify {
+    my $s = shift;
+    my %args = @_;
+
+    my $uuid = $s->identifier;
+    if ($args{short}) {
+        if ($uuid =~ /^(\w+)-(\w+)-(\w+)-(\w+)-(\w+)$/) {
+            return $1;
+        }
+    }
+
+    my $long_name = '';
+    my $type = $s->attrs->{reftype};
+    if ($type)
+    {
+        $long_name .= $type . '. ';
+    }
+    my $date = $s->attrs->{Date};
+    if ($date)
+    {
+        $long_name .= $date . '. ';
+    }
+    my $author = $s->attrs->{Author};
+    if ($author) {
+        my @list = split /\x{d}/, $author;
+        $long_name .= $list[0];
+        $long_name =~ s/,.*$//;
+        $long_name .= ' et al.' if @list > 1;
+    }
+    return length $long_name ? $long_name :: $uuid;
+}
+
+
 sub type {
     return shift->attrs->{reftype};
 }

--- a/lib/Tuba/DB/Mixin/Object/Reference.pm
+++ b/lib/Tuba/DB/Mixin/Object/Reference.pm
@@ -40,6 +40,7 @@ sub as_tree {
             } $s->publications
         ];
     }
+    $t->{description} = $s->stringify;
     return $t;
 }
 

--- a/lib/Tuba/Dataset.pm
+++ b/lib/Tuba/Dataset.pm
@@ -35,6 +35,7 @@ sub make_tree_for_show {
     $tree->{instrument_measurements} = [
         map $_->as_tree, $dataset->instrument_measurements
     ];
+    $tree->{title} = $tree->{name};
     return $tree;
 }
 

--- a/lib/Tuba/Dataset.pm
+++ b/lib/Tuba/Dataset.pm
@@ -35,7 +35,6 @@ sub make_tree_for_show {
     $tree->{instrument_measurements} = [
         map $_->as_tree, $dataset->instrument_measurements
     ];
-    $tree->{title} = $tree->{name};
     return $tree;
 }
 

--- a/lib/Tuba/Figure.pm
+++ b/lib/Tuba/Figure.pm
@@ -85,6 +85,15 @@ sub show {
     $c->SUPER::show(@_);
 }
 
+sub make_tree_for_show {
+    my $c = shift;
+    my $figure = shift;
+    my $tree = $c->SUPER::make_tree_for_show($figure, @_ );
+    $tree->{description} = $tree->{caption};
+    return $tree;
+}
+
+
 sub update_form {
     my $c = shift;
     my $object = $c->_this_object or return $c->reply->not_found;

--- a/lib/Tuba/files/templates/article/object.html.ep
+++ b/lib/Tuba/files/templates/article/object.html.ep
@@ -13,6 +13,10 @@
         <h4><%= $article->year %></h4>
         % }
         %= include 'h/contributors', object => $article;
+        % if ($article->description) {
+        <h5>Description</h5>
+        <p><%= $article->description %></p>
+        % }
         <%= obj_link($article->journal) %>
         % if ($article->journal_vol) {
         volume <%= $article->journal_vol %>

--- a/lib/Tuba/files/templates/article/object.ttl.tut
+++ b/lib/Tuba/files/templates/article/object.ttl.tut
@@ -9,7 +9,7 @@
    bibo:pages "<%= $article->journal_pages %>";
    dbpprop:pubYear "<%= $article->year %>"^^xsd:gYear;
 % if ($article->description) {
-   dcterms:description "<%= $article->description %>";
+   dcterms:description "<%= $article->description %>"^^xsd:string;
 % }
 % if ($article->doi) {
    bibo:doi "<%= $article->doi %>";

--- a/lib/Tuba/files/templates/article/object.ttl.tut
+++ b/lib/Tuba/files/templates/article/object.ttl.tut
@@ -8,6 +8,9 @@
    bibo:volume "<%= $article->journal_vol %>";
    bibo:pages "<%= $article->journal_pages %>";
    dbpprop:pubYear "<%= $article->year %>"^^xsd:gYear;
+% if ($article->description) {
+   dcterms:description "<%= $article->description %>";
+% }
 % if ($article->doi) {
    bibo:doi "<%= $article->doi %>";
 % } else {

--- a/t/009_article.t
+++ b/t/009_article.t
@@ -63,6 +63,7 @@ $t->get_ok("/journal/nurture.json")->json_is(
 my %a = (
  identifier         => '10.123/456',
  title              => 'nature vs nurture',
+ description        => 'nature vs nurture abstract here',
  doi                => '10.123/456',
  year               => '2001',
  journal_identifier => 'nature',


### PR DESCRIPTION
In support of #369:

 - `Chapter` now has a `description` field that is return via the json API.
 - `Figure` json API returns a `description`, which is an alias for the existing `caption`
 - `Finding` json API returns a `description`, which is an alias for the existing `statement`
 - `Journal` now has a `description` field that is returned via the json API.
 - `Article` now has a `description` field that is
   - returned via the json API
   - displayed via the html requests, if it is populated
   - is returned as in the turtle as `dcterms:description`
 - `Webpage` now has a `description` field that is returned via the json API.
 - `Book` now has a `description` field that is returned via the json API.
 - `Dataset` now has a `description` field that is returned via the json API.
