### PR TITLE
Fix travis build post Postgres9.2 EoL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ addons:
             - raptor2-utils
             - postgresql-9.3
             - postgresql-contrib-9.3
-            - postgresql-dev-9.3
             - libuuid1
             - uuid-dev
             - openssl

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ addons:
             - raptor2-utils
             - postgresql-9.3
             - postgresql-contrib-9.3
+            - postgresql-server-dev-9.3
             - libuuid1
             - uuid-dev
             - openssl

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,15 @@ addons:
     apt:
         packages:
             - raptor2-utils
-            - postgresql
+            - postgresql-9.3
+            - postgresql-contrib-9.3
+            - postgresql-dev-9.3
+            - libuuid1
+            - uuid-dev
+            - openssl
+            - libssl-dev
+            - libpq-dev
+            - libxml2
 
 perl:
   - "5.20"


### PR DESCRIPTION
In migrating from postgres 9.2 to 9.3, the required packages changed to include the `server` package. made the requirements for travis more robust in general.