### PR TITLE
Create thumbnail on all file puts. This addresses issue #672.

### DIFF
--- a/lib/Tuba/Controller.pm
+++ b/lib/Tuba/Controller.pm
@@ -982,6 +982,7 @@ sub put_files {
     my $tfile = $pub->upload_file(c => $c, upload => $file) or do {
         return $c->render(status => 500, text => $pub->error);
     };
+    $tfile->generate_thumbnail(); 
     $c->render(status => 200, json => { identifier => $tfile->identifier });
 }
 


### PR DESCRIPTION
On all file uploads, call the routine to generate a thumbnail. The underlying function handles checking for the existence of a thumbnail and handles file types.